### PR TITLE
Install ca-certificates on idl client image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,9 @@ WORKDIR /output
 COPY --from=build /build/coverage.txt ./
 
 FROM ubuntu:18.04 as idl
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
+    && apt-get -y install --no-install-recommends ca-certificates 2>&1
 ENTRYPOINT ["/app/idl"]
 VOLUME /data
 WORKDIR /data


### PR DESCRIPTION
Install ca-certificates from apt on idl client Docker image.  

## Motivation and Context
This way, we can post IDLs to repositories secured by, e.g. Let's Encrypt.

## How Has This Been Tested?
I tested locally using the update docker images.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
